### PR TITLE
Trap SIGTERM during docker stop

### DIFF
--- a/start-xvfb-nginx.sh
+++ b/start-xvfb-nginx.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 
 cleanup() {
+    # SIGTERM is propagated to children.
+    # Timeout is managed directly by Docker, via it's '-t' flag:
+    # if SIGTERM does not teminate the entrypoint, after the time
+    # defined by '-t' (default 10 secs) the container is killed
     kill $XVFB_PID $QGIS_PID
 }
 

--- a/start-xvfb-nginx.sh
+++ b/start-xvfb-nginx.sh
@@ -1,9 +1,17 @@
 #!/bin/bash
 
+cleanup() {
+    kill $XVFB_PID $QGIS_PID
+}
+
+trap cleanup SIGINT SIGTERM
+
 rm -f /tmp/.X99-lock
 /usr/bin/Xvfb :99 -ac -screen 0 1280x1024x16 +extension GLX +render -noreset >/dev/null &
 while ! pidof /usr/bin/Xvfb >/dev/null; do
     sleep 1
 done
-spawn-fcgi -u qgis -g qgis -d /tmp -p 9993 -- /usr/libexec/qgis/qgis_mapserv.fcgi
-nginx -g "daemon off;";
+XVFB_PID=$(pidof /usr/bin/Xvfb)
+spawn-fcgi -u qgis -g qgis -d /tmp -P /tmp/qgis.pid -p 9993 -- /usr/libexec/qgis/qgis_mapserv.fcgi
+QGIS_PID=$(pidof /usr/libexec/qgis/qgis_mapserv.fcgi)
+exec nginx -g "daemon off;";


### PR DESCRIPTION
We must propagate the `SIGTERM` to the spawned processes to be able to stop properly the container properly