### PR TITLE
Improve NGIX conf and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 ## QGIS 3 server via Docker
 
+### Available tags
+
+- `openquake/qgis-server:3` | `openquake/qgis-server:3.4` | `openquake/qgis-server:3.4.0`: Based on latest QGIS 3.4
+- `openquake/qgis-server:3.2` | `openquake/qgis-server:3.2.3`: Based on QGIS 3.2
+
 ### Build the container
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It includes *Nginx* and *Xvfb* and can be used as a standalone service (via HTTP
 ### Services provided
 
 This Docker container exposes HTTP on port `80` via Nginx and a direct FastCGI on port `9993` that can be used directly by an external HTTP proxy (like the provided `docker-compose.yml` does).
-A sample Inginx configuration for using it as a *FastCGI* backend is also [provided](conf/nginx-fcgi-sample.conf).
+A sampleg Nginx configuration for using it as a *FastCGI* backend is also [provided](conf/nginx-fcgi-sample.conf).
 
 ### Available tags
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,21 @@
 ## QGIS 3 server via Docker
 
+[![Build Status](https://travis-ci.org/gem/oq-qgis-server.svg?branch=master)](https://travis-ci.org/gem/oq-qgis-server)
+
+### General information
+
+The Docker image is built using *Fedora 27* and QGIS RPMs from https://copr.fedorainfracloud.org/coprs/dani/qgis/.
+It includes *Nginx* and *Xvfb* and can be used as a standalone service (via HTTP TCP port 80) or as *FCGI* backend (via TCP port 9993).
+
+### Services provided
+
+This Docker container exposes HTTP on port `80` via Nginx and a direct FastCGI on port `9993` that can be used directly by an external HTTP proxy (like the provided `docker-compose.yml` does).
+A sample Inginx configuration for using it as a *FastCGI* backend is also [provided](conf/nginx-fcgi-sample.conf).
+
 ### Available tags
 
-- `openquake/qgis-server:3` | `openquake/qgis-server:3.4` | `openquake/qgis-server:3.4.0`: Based on latest QGIS 3.4
-- `openquake/qgis-server:3.2` | `openquake/qgis-server:3.2.3`: Based on QGIS 3.2
+- `openquake/qgis-server:latest` | `openquake/qgis-server:3` | `openquake/qgis-server:3.4` | `openquake/qgis-server:3.4.0`: Based on latest **QGIS 3.4**
+- `openquake/qgis-server:3.2` | `openquake/qgis-server:3.2.3`: Based on **QGIS 3.2**
 
 ### Build the container
 
@@ -63,7 +75,3 @@ plugins
       |-- metadata.txt
       |-- __init__.py
 ```
-
-### Services provided
-
-This Docker container exposes HTTP on port `80` via Nginx and a direct FastCGI on port `9993` that can be used directly by an external HTTP proxy (like the provided `docker-compose.yml` does)

--- a/conf/nginx-fcgi-sample.conf
+++ b/conf/nginx-fcgi-sample.conf
@@ -56,9 +56,17 @@ http {
         root         /usr/share/nginx/html;
 
         location / {
-            root /var/www/data;
+            root /var/www/html;
+        }
+
+        location /ogc/ {
             rewrite ^/ogc/(.*)$ /qgis/qgis_mapserv.fcgi?map=/io/data/$1/$1.qgs;
-            fastcgi_pass  qgis-fcgi;
+        }
+
+        location /qgis/ {
+            nternal; # Used only by the OGC rewrite
+            root /var/www/data;
+            fastcgi_pass  localhost:9993;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             fastcgi_param QUERY_STRING    $query_string;
         }

--- a/conf/nginx-fcgi-sample.conf
+++ b/conf/nginx-fcgi-sample.conf
@@ -49,6 +49,30 @@ http {
         server docker_qgis-server_3:9993;
     }
 
+    # Get 'port' from `$http_host`
+    map $http_host $port {
+        "~*.*:(?<p>.*)" $p;
+        default server_port;
+    }
+    # Get 'proto' from `$scheme` unless 'X-Forwarded-Proto'
+    # is set by the reverse proxy
+    map $http_x_forwarded_proto $qgis_proto {
+        "" $scheme;
+        default $http_x_forwarded_proto;
+    }
+    # Get 'host' from `$host` unless 'X-Forwarded-Host'
+    # is set by the reverse proxy
+    map $http_x_forwarded_host $qgis_host {
+        "" $host;
+        default $http_x_forwarded_host;
+    }
+    # Get 'port' from `$port` unless 'X-Forwarded-Port'
+    # is set by the reverse proxy
+    map $http_x_forwarded_port $qgis_port {
+        "" $port;
+        default $http_x_forwarded_port;
+    }
+
     server {
         listen       80 default_server;
         listen       [::]:80 default_server;
@@ -58,11 +82,9 @@ http {
         location / {
             root /var/www/html;
         }
-
         location /ogc/ {
             rewrite ^/ogc/(.*)$ /qgis/qgis_mapserv.fcgi?map=/io/data/$1/$1.qgs;
         }
-
         location /qgis/ {
             internal; # Used only by the OGC rewrite
             root /var/www/data;
@@ -71,15 +93,13 @@ http {
             fastcgi_param QUERY_STRING    $query_string;
             # build links in GetCapabilities based on
             # the hostname exposed by the reverse proxy
-            # custom port is currently not supported
-            fastcgi_param  SERVER_NAME $host;
-            fastcgi_param  SERVER_PROTOCOL $scheme;
+            fastcgi_param  SERVER_PROTOCOL $qgis_proto;
+            fastcgi_param  SERVER_NAME $qgis_host;
+            fastcgi_param  SERVER_PORT $qgis_port;
         }
-
         error_page 404 /404.html;
             location = /40x.html {
         }
-
         error_page 500 502 503 504 /50x.html;
             location = /50x.html {
         }

--- a/conf/nginx-fcgi-sample.conf
+++ b/conf/nginx-fcgi-sample.conf
@@ -64,11 +64,16 @@ http {
         }
 
         location /qgis/ {
-            nternal; # Used only by the OGC rewrite
+            internal; # Used only by the OGC rewrite
             root /var/www/data;
             fastcgi_pass  localhost:9993;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             fastcgi_param QUERY_STRING    $query_string;
+            # build links in GetCapabilities based on
+            # the hostname exposed by the reverse proxy
+            # custom port is currently not supported
+            fastcgi_param  SERVER_NAME $host;
+            fastcgi_param  SERVER_PROTOCOL $scheme;
         }
 
         error_page 404 /404.html;

--- a/conf/qgis-server-nginx.conf
+++ b/conf/qgis-server-nginx.conf
@@ -45,6 +45,30 @@ http {
     include             /etc/nginx/mime.types;
     default_type        application/octet-stream;
 
+    # Get 'port' from `$http_host`
+    map $http_host $port {
+        "~*.*:(?<p>.*)" $p;
+        default server_port;
+    }
+    # Get 'proto' from `$scheme` unless 'X-Forwarded-Proto'
+    # is set by the reverse proxy
+    map $http_x_forwarded_proto $qgis_proto {
+        "" $scheme;
+        default $http_x_forwarded_proto;
+    }
+    # Get 'host' from `$host` unless 'X-Forwarded-Host'
+    # is set by the reverse proxy
+    map $http_x_forwarded_host $qgis_host {
+        "" $host;
+        default $http_x_forwarded_host;
+    }
+    # Get 'port' from `$port` unless 'X-Forwarded-Port'
+    # is set by the reverse proxy
+    map $http_x_forwarded_port $qgis_port {
+        "" $port;
+        default $http_x_forwarded_port;
+    }
+
     server {
         listen       80 default_server;
         listen       [::]:80 default_server;
@@ -54,7 +78,6 @@ http {
         location /ogc/ {
             rewrite ^/ogc/(.*)$ /qgis/qgis_mapserv.fcgi?map=/io/data/$1/$1.qgs;
         }
-
         location /qgis/ {
             internal; # Used only by the OGC rewrite
             root /var/www/data;
@@ -63,15 +86,13 @@ http {
             fastcgi_param QUERY_STRING    $query_string;
             # build links in GetCapabilities based on
             # the hostname exposed by the reverse proxy
-            # custom port is currently not supported
-            fastcgi_param  SERVER_NAME $host;
-            fastcgi_param  SERVER_PROTOCOL $scheme;
+            fastcgi_param  SERVER_PROTOCOL $qgis_proto;
+            fastcgi_param  SERVER_NAME $qgis_host;
+            fastcgi_param  SERVER_PORT $qgis_port;
         }
-
         error_page 404 /404.html;
             location = /40x.html {
         }
-
         error_page 500 502 503 504 /50x.html;
             location = /50x.html {
         }

--- a/conf/qgis-server-nginx.conf
+++ b/conf/qgis-server-nginx.conf
@@ -56,11 +56,16 @@ http {
         }
 
         location /qgis/ {
-            nternal; # Used only by the OGC rewrite
+            internal; # Used only by the OGC rewrite
             root /var/www/data;
             fastcgi_pass  localhost:9993;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             fastcgi_param QUERY_STRING    $query_string;
+            # build links in GetCapabilities based on
+            # the hostname exposed by the reverse proxy
+            # custom port is currently not supported
+            fastcgi_param  SERVER_NAME $host;
+            fastcgi_param  SERVER_PROTOCOL $scheme;
         }
 
         error_page 404 /404.html;

--- a/conf/qgis-server-nginx.conf
+++ b/conf/qgis-server-nginx.conf
@@ -51,9 +51,13 @@ http {
         server_name  _;
         root         /usr/share/nginx/html;
 
-        location / {
-            root /var/www/data;
+        location /ogc/ {
             rewrite ^/ogc/(.*)$ /qgis/qgis_mapserv.fcgi?map=/io/data/$1/$1.qgs;
+        }
+
+        location /qgis/ {
+            nternal; # Used only by the OGC rewrite
+            root /var/www/data;
             fastcgi_pass  localhost:9993;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             fastcgi_param QUERY_STRING    $query_string;


### PR DESCRIPTION
Preparing for the `3.4` release I've update a bit the nginx configuration to be more clean and flexible.

Since `server_name`, which is used to populate `SERVER_NAME` in FastCGI, cannot be know a priori we use the `Host` header to set it. Same is done for `Scheme`. `Port` is taken splitting `$http_host`
These variables are used by QGIS server to build `GetCapabilities` URLs.
If a reverse proxy sets `X-Forwarded-*` those are used instead.


It can be tested via tag `3.4`. (see https://github.com/gem/oq-qgis-server/blob/master/.travis.yml for an example). You should get

```xml
<OnlineResource xlink:type="simple" xlink:href="http://localhost:8010?map=/io/data/test_project/test_project.qgs&service=WMS&request=GetCapabilities"/>
```
instead of

```xml
<OnlineResource xlink:type="simple" xlink:href="http:?map=/io/data/test_project/test_project.qgs&service=WMS&request=GetCapabilities"/>
```