### PR TITLE
include default fastcgi_params to allow for example POST requests

### DIFF
--- a/conf/nginx-fcgi-sample.conf
+++ b/conf/nginx-fcgi-sample.conf
@@ -89,6 +89,8 @@ http {
             internal; # Used only by the OGC rewrite
             root /var/www/data;
             fastcgi_pass  qgis-fcgi:9993;
+           
+            include fastcgi_params;  
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             fastcgi_param QUERY_STRING    $query_string;
             # build links in GetCapabilities based on

--- a/conf/qgis-server-nginx.conf
+++ b/conf/qgis-server-nginx.conf
@@ -82,6 +82,8 @@ http {
             internal; # Used only by the OGC rewrite
             root /var/www/data;
             fastcgi_pass  localhost:9993;
+            
+            include fastcgi_params;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             fastcgi_param QUERY_STRING    $query_string;
             # build links in GetCapabilities based on


### PR DESCRIPTION
doing things like: 
```
curl --output - --data "bbox=2551359,1211640,2556386,1213982&crs=EPSG%3A2056&dpi=96&&format=image%2Fpng&height=885&layers=pont&map=%2Fio%2Fdata%2Fproject%2Eqgs&request=GetMap&service=WMS&width=1900" http://HOST_IP/cgi-bin/qgis_mapserv.fcgi  
```
 
Fail without 
```
fastcgi_param REQUEST_METHOD $request_method;
fastcgi_param CONTENT_TYPE $content_type;
fastcgi_param CONTENT_LENGTH $content_length;
fastcgi_param REQUEST_BODY $request_body;
```

adding `include fastcgi_params;` is the standard way to add this