### PR TITLE
Add support for LTR and move to F29 (F27 EoL)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,11 +18,13 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-FROM fedora:27
+FROM fedora:29
 MAINTAINER Daniele Viganò <daniele@openquake.org>
 
+ARG repo=qgis
+
 RUN dnf -y install dnf-plugins-core xorg-x11-server-Xvfb && \
-    dnf copr enable -y dani/qgis && \
+    dnf copr enable -y dani/$repo && \
     dnf install -y nginx spawn-fcgi qgis-server && \
     dnf clean all
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,11 @@
 
 ### General information
 
-The Docker image is built using *Fedora 27* and QGIS RPMs from https://copr.fedorainfracloud.org/coprs/dani/qgis/.
+The Docker image is built using *Fedora 29* and QGIS RPMs from https://copr.fedorainfracloud.org/coprs/dani/qgis/ (QGIS 3.6) and https://copr.fedorainfracloud.org/coprs/dani/qgis-ltr/ (QGIS 3.4 LTR).
 It includes *Nginx* and *Xvfb* and can be used as a standalone service (via HTTP TCP port 80) or as *FCGI* backend (via TCP port 9993).
+
+To be able to run these containers you need **Docker >= 18.04** or you need to run containers in 'privileged' mode since the `statx` syscall is required by Qt 5.11.
+See https://github.com/gem/oq-qgis-server/issues/1
 
 ### Services provided
 
@@ -25,9 +28,18 @@ $ docker pull openquake/qgis-server:3.4
 
 ### Build the container
 
+#### QGIS 3.6
+
 ```bash
-$ docker build --rm=true -t openquake/qgis-server:3.4 -f Dockerfile .
+$ docker build -t openquake/qgis-server:3.6 -f Dockerfile .
 ```
+
+#### QGIS 3.4 LTR
+
+```bash
+$ docker build --build-arg repo=qgis-ltr -t openquake/qgis-server:3.4 -f Dockerfile .
+```
+
 You may skip this step. The container will be downloaded from the Docker Hub.
 
 ### Run the docker and map host data


### PR DESCRIPTION
F27 has reached the EoL, so we are forced to move to F29. Now #1 applies to new containers, so a recent version of Docker (>=18.04) is required (or `statx` must be added manually to `/etc/docker/seccomp.json`