### PR TITLE
Make .local/share/QGIS profile folder working

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,10 @@ ENV QGIS_SERVER_MAX_THREADS 2
 ENV QT_GRAPHICSSYSTEM raster
 ENV DISPLAY :99
 
-WORKDIR /tmp
+RUN mkdir /var/lib/qgis && \
+    chmod 1777 /var/lib/qgis
+ENV HOME /var/lib/qgis
+WORKDIR $HOME
 
 EXPOSE 80
 CMD /usr/local/bin/start-xvfb-nginx.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # vim: syntax=dockerfile
 #
 # oq-qgis-server
-# Copyright (C) 2018 GEM Foundation
+# Copyright (C) 2018-2019 GEM Foundation
 #
 # oq-qgis-server is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by

--- a/conf/nginx-fcgi-sample.conf
+++ b/conf/nginx-fcgi-sample.conf
@@ -2,7 +2,7 @@
 # vim: tabstop=4 shiftwidth=4 softtabstop=4
 #
 # oq-qgis-server
-# Copyright (C) 2018 GEM Foundation
+# Copyright (C) 2018-2019 GEM Foundation
 #
 # oq-qgis-server is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by

--- a/conf/qgis-server-nginx.conf
+++ b/conf/qgis-server-nginx.conf
@@ -2,7 +2,7 @@
 # vim: tabstop=4 shiftwidth=4 softtabstop=4
 #
 # oq-qgis-server
-# Copyright (C) 2018 GEM Foundation
+# Copyright (C) 2018-2019 GEM Foundation
 #
 # oq-qgis-server is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@
 # vim: tabstop=4 shiftwidth=4 softtabstop=4
 #
 # oq-qgis-server
-# Copyright (C) 2018 GEM Foundation
+# Copyright (C) 2018-2019 GEM Foundation
 #
 # oq-qgis-server is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by

--- a/start-xvfb-nginx.sh
+++ b/start-xvfb-nginx.sh
@@ -3,7 +3,7 @@
 # vim: tabstop=4 shiftwidth=4 softtabstop=4
 #
 # oq-qgis-server
-# Copyright (C) 2018 GEM Foundation
+# Copyright (C) 2018-2019 GEM Foundation
 #
 # oq-qgis-server is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by

--- a/start-xvfb-nginx.sh
+++ b/start-xvfb-nginx.sh
@@ -36,6 +36,6 @@ while ! pidof /usr/bin/Xvfb >/dev/null; do
 done
 XVFB_PID=$(pidof /usr/bin/Xvfb)
 # To avoid issues with GeoPackages when scaling out QGIS should not run as root
-spawn-fcgi -n -u ${QGIS_USER:-nginx} -g ${QGIS_USER:-nginx} -d /tmp -P /tmp/qgis.pid -p 9993 -- /usr/libexec/qgis/qgis_mapserv.fcgi &
+spawn-fcgi -n -u ${QGIS_USER:-nginx} -g ${QGIS_USER:-nginx} -d /var/lib/qgis -P /run/qgis.pid -p 9993 -- /usr/libexec/qgis/qgis_mapserv.fcgi &
 QGIS_PID=$(pidof /usr/libexec/qgis/qgis_mapserv.fcgi)
 exec nginx -g "daemon off;";


### PR DESCRIPTION
In our docker container we do not have a 'qgis' user: this allows `uid` to be specified at runtime, per container, without requiring a full rebuild of it.

Because of that and because `spawn-fcgi` does not set `$HOME` based on `-u ${QGIS_USER:-nginx}` the QGIS profile folder was expected under `/root/.local`. Since the fcgi process is properly run by `${QGIS_USER:-nginx}` such user was indeed not able to write to `/root/.local`.
The missing profile folders was preventing the `Auth DB` to be created: this has several side effects, like with basemaps using https.

It looks like that there's no way to customize where the QGIS server profile is located: it can be done when using the GUI via `--profiles-path` and `QGIS_OPTIONS_PATH` changes only where the configuration file in saved (and not the entire profile).

To avoid this issue a generic `/var/lib/qgis` is created with `1777` (as `/tmp` is, because we don't know who will run QGIS upfront and I don't want to make the entry point logic too complex) and `$HOME` is then set to that folder.