### PR TITLE
Make QGIS the main entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,14 @@ plugins
 
 The following variables can be customized during container deployment:
 
+#### Nginx
+
+- `SKIP_NGINX`: deault is `false`
+
+When `SKIP_NGINX` is set the embedded copy of Nginx will not be started and an external reverse proxy is then required to access the FastCGI QGIS backend.
+
+#### QGIS
+
 - `QGIS_SERVER_LOG_LEVEL`: default is `1`
 - `QGIS_SERVER_PARALLEL_RENDERING`: default is `true`
 - `QGIS_SERVER_MAX_THREADS`: default is `2`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,8 @@ services:
   qgis-server:
     image: "openquake/qgis-server:3"
     environment:
+      # Do not run the embedded copy of nginx
+      SKIP_NGINX: "true"
       QGIS_SERVER_PARALLEL_RENDERING: "true"
       QGIS_SERVER_MAX_THREADS: 4
     networks:

--- a/start-xvfb-nginx.sh
+++ b/start-xvfb-nginx.sh
@@ -24,18 +24,29 @@ cleanup() {
     # Timeout is managed directly by Docker, via it's '-t' flag:
     # if SIGTERM does not teminate the entrypoint, after the time
     # defined by '-t' (default 10 secs) the container is killed
-    kill $XVFB_PID $NGINX_PID
+    kill $XVFB_PID $QGIS_PID $NGINX_PID
+}
+
+waitfor() {
+    # Make startup syncronous
+    while ! pidof $1 >/dev/null; do
+        sleep 1
+    done
+    pidof $1
 }
 
 trap cleanup SIGINT SIGTERM
 
 rm -f /tmp/.X99-lock
 /usr/bin/Xvfb :99 -ac -screen 0 1280x1024x16 +extension GLX +render -noreset >/dev/null &
-while ! pidof /usr/bin/Xvfb >/dev/null; do
-    sleep 1
-done
-XVFB_PID=$(pidof /usr/bin/Xvfb)
-nginx
-NGINX_PID=$(pidof /usr/bin/nginx)
+XVFB_PID=$(waitfor /usr/bin/Xvfb)
+# Do not start NGINX if environment variable '$SKIP_NGINX' is set
+# this may be useful in production where an external reverse proxy is used
+if [ -z $SKIP_NGINX ]; then
+    nginx
+    NGINX_PID=$(waitfor /usr/sbin/nginx)
+fi
 # To avoid issues with GeoPackages when scaling out QGIS should not run as root
-exec spawn-fcgi -n -u ${QGIS_USER:-nginx} -g ${QGIS_USER:-nginx} -d /var/lib/qgis -P /run/qgis.pid -p 9993 -- /usr/libexec/qgis/qgis_mapserv.fcgi
+spawn-fcgi -n -u ${QGIS_USER:-nginx} -g ${QGIS_USER:-nginx} -d /var/lib/qgis -P /run/qgis.pid -p 9993 -- /usr/libexec/qgis/qgis_mapserv.fcgi &
+QGIS_PID=$(waitfor /usr/libexec/qgis/qgis_mapserv.fcgi)
+wait $QGIS_PID

--- a/start-xvfb-nginx.sh
+++ b/start-xvfb-nginx.sh
@@ -24,7 +24,7 @@ cleanup() {
     # Timeout is managed directly by Docker, via it's '-t' flag:
     # if SIGTERM does not teminate the entrypoint, after the time
     # defined by '-t' (default 10 secs) the container is killed
-    kill $XVFB_PID $QGIS_PID
+    kill $XVFB_PID $NGINX_PID
 }
 
 trap cleanup SIGINT SIGTERM
@@ -35,7 +35,7 @@ while ! pidof /usr/bin/Xvfb >/dev/null; do
     sleep 1
 done
 XVFB_PID=$(pidof /usr/bin/Xvfb)
+nginx
+NGINX_PID=$(pidof /usr/bin/nginx)
 # To avoid issues with GeoPackages when scaling out QGIS should not run as root
-spawn-fcgi -n -u ${QGIS_USER:-nginx} -g ${QGIS_USER:-nginx} -d /var/lib/qgis -P /run/qgis.pid -p 9993 -- /usr/libexec/qgis/qgis_mapserv.fcgi &
-QGIS_PID=$(pidof /usr/libexec/qgis/qgis_mapserv.fcgi)
-exec nginx -g "daemon off;";
+exec spawn-fcgi -n -u ${QGIS_USER:-nginx} -g ${QGIS_USER:-nginx} -d /var/lib/qgis -P /run/qgis.pid -p 9993 -- /usr/libexec/qgis/qgis_mapserv.fcgi


### PR DESCRIPTION
So if it fails the container die and it can be restarted/respawned

Also make the Nginx embedded inside the QGIS container optional