### PR TITLE
add qt5-image-formats-plugins to support webp

### DIFF
--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -30,7 +30,7 @@ RUN apt update && apt install -y gnupg && \
     echo "deb     http://qgis.org/${repo} ${ubuntu_dist} main" >> /etc/apt/sources.list && \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-key F7E06F06199EF2F2 && \
     apt update && \
-    DEBIAN_FRONTEND=noninteractive apt install -y xvfb nginx-core spawn-fcgi qgis-server python3-qgis && \
+    DEBIAN_FRONTEND=noninteractive apt install -y xvfb nginx-core spawn-fcgi qgis-server qt5-image-formats-plugins python3-qgis && \
     apt clean all
 
 # This part is kept to allow the container to be used in


### PR DESCRIPTION
@daniviga do you think this would be cleaner directly in the qgis deb packages? if so can you point me to where I should do the change?

I tested within a container doing so:
```
from PyQt5 import QtGui

QtGui.QImageWriter.supportedImageFormats()
# without qt5-image-formats-plugins
#>>> [PyQt5.QtCore.QByteArray(b'bmp'), PyQt5.QtCore.QByteArray(b'cur'), PyQt5.QtCore.QByteArray(b'ico'), PyQt5.QtCore.QByteArray(b'jpeg'), PyQt5.QtCore.QByteArray(b'jpg'), PyQt5.QtCore.QByteArray(b'pbm'), PyQt5.QtCore.QByteArray(b'pgm'), PyQt5.QtCore.QByteArray(b'png'), PyQt5.QtCore.QByteArray(b'ppm'), PyQt5.QtCore.QByteArray(b'xbm'), PyQt5.QtCore.QByteArray(b'xpm')]

# with qt5-image-formats-plugins
#>>> [PyQt5.QtCore.QByteArray(b'bmp'), PyQt5.QtCore.QByteArray(b'cur'), PyQt5.QtCore.QByteArray(b'icns'), PyQt5.QtCore.QByteArray(b'ico'), PyQt5.QtCore.QByteArray(b'jpeg'), PyQt5.QtCore.QByteArray(b'jpg'), PyQt5.QtCore.QByteArray(b'pbm'), PyQt5.QtCore.QByteArray(b'pgm'), PyQt5.QtCore.QByteArray(b'png'), PyQt5.QtCore.QByteArray(b'ppm'), PyQt5.QtCore.QByteArray(b'tif'), PyQt5.QtCore.QByteArray(b'tiff'), PyQt5.QtCore.QByteArray(b'wbmp'), PyQt5.QtCore.QByteArray(b'webp'), PyQt5.QtCore.QByteArray(b'xbm'), PyQt5.QtCore.QByteArray(b'xpm')]
i = QtGui.QImage()
i.load('/io/data/test.png')
#>>> True
i.save('/io/data/res.webp')
#>>> True with qt5-image-formats-plugins, False without
``` 

please note that for webp to work correctly it requires also https://github.com/qgis/QGIS/pull/39762