### PR TITLE
update ubuntu dist to focal

### DIFF
--- a/.github/workflows/build_docker_images.yml
+++ b/.github/workflows/build_docker_images.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 env:
-  UBUNTU_DIST: 'bionic'
+  UBUNTU_DIST: 'focal'
 
 jobs:
   build-nightly:


### PR DESCRIPTION
QGIS 3.18+ requires more recent deps than what offers bionic. 
I propose to update to focal which is the latest LTS